### PR TITLE
feat: integrate Prometheus metrics endpoint and monitoring config

### DIFF
--- a/flask-app/requirements.txt
+++ b/flask-app/requirements.txt
@@ -11,3 +11,4 @@ psutil==7.0.0
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
+prometheus_client

--- a/flask-app/src/routes/health.py
+++ b/flask-app/src/routes/health.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, Response
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST, Gauge
 import time
 import psutil
 import os
@@ -8,9 +9,13 @@ health_bp = Blueprint('health', __name__)
 
 start_time = time.time()
 
+# Definindo métricas
+cpu_usage = Gauge('system_cpu_percent', 'Uso de CPU (%)')
+mem_usage = Gauge('system_memory_percent', 'Uso de memória (%)')
+uptime = Gauge('system_uptime_seconds', 'Uptime da aplicação (segundos)')
+
 @health_bp.route('/health', methods=['GET'])
 def health_check():
-    """Endpoint de health check para verificação de saúde da aplicação"""
     return jsonify({
         'status': 'healthy',
         'timestamp': datetime.utcnow().isoformat(),
@@ -20,41 +25,25 @@ def health_check():
 
 @health_bp.route('/metrics', methods=['GET'])
 def metrics():
-    """Endpoint de métricas básicas para monitoramento"""
+    """Endpoint de métricas compatível com Prometheus"""
     try:
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu = psutil.cpu_percent(interval=1)
         memory = psutil.virtual_memory()
-        disk = psutil.disk_usage('/')
-        
-        return jsonify({
-            'timestamp': datetime.utcnow().isoformat(),
-            'uptime_seconds': int(time.time() - start_time),
-            'system': {
-                'cpu_percent': cpu_percent,
-                'memory_percent': memory.percent,
-                'memory_used_mb': memory.used // (1024 * 1024),
-                'memory_total_mb': memory.total // (1024 * 1024),
-                'disk_percent': (disk.used / disk.total) * 100,
-                'disk_used_gb': disk.used // (1024 * 1024 * 1024),
-                'disk_total_gb': disk.total // (1024 * 1024 * 1024)
-            },
-            'application': {
-                'version': '1.0.0',
-                'environment': os.getenv('ENVIRONMENT', 'development'),
-                'process_id': os.getpid()
-            }
-        }), 200
+        up = int(time.time() - start_time)
+
+        # Atualiza métricas Prometheus
+        cpu_usage.set(cpu)
+        mem_usage.set(memory.percent)
+        uptime.set(up)
+
+        # Retorna no formato Prometheus
+        return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
     except Exception as e:
-        return jsonify({
-            'error': 'Failed to collect metrics',
-            'message': str(e)
-        }), 500
+        return Response(f"# erro: {str(e)}", status=500, mimetype="text/plain")
 
 @health_bp.route('/ready', methods=['GET'])
 def readiness_check():
-    """Endpoint de readiness para Kubernetes/ECS"""
     return jsonify({
         'status': 'ready',
         'timestamp': datetime.utcnow().isoformat()
     }), 200
-

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -4,5 +4,5 @@ global:
 scrape_configs:
   - job_name: 'flask_app'
     static_configs:
-      - targets: ['devops-mini-project-lb-2070178412.us-east-1.elb.amazonaws.com']
+      - targets: ['devops-mini-project-lb-591531424.us-east-1.elb.amazonaws.com']
     metrics_path: /api/metrics

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -4,5 +4,5 @@ global:
 scrape_configs:
   - job_name: 'flask_app'
     static_configs:
-      - targets: ['devops-mini-project-lb-53814840.us-east-1.elb.amazonaws.com:80']
+      - targets: ['devops-mini-project-lb-2070178412.us-east-1.elb.amazonaws.com']
     metrics_path: /api/metrics

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -4,5 +4,5 @@ global:
 scrape_configs:
   - job_name: 'flask_app'
     static_configs:
-      - targets: ['devops-mini-project-lb-591531424.us-east-1.elb.amazonaws.com']
+      - targets: ['<REPLACE_WITH_LOAD_BALANCER_DNS>'] # TODO: Replace with your Load Balancer DNS name
     metrics_path: /api/metrics

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,6 +78,13 @@ resource "aws_security_group" "ecs_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
Summary of changes

This PR introduces Prometheus-compatible system metrics to the Flask backend and updates the infrastructure configuration to expose the new metrics endpoint.

Main changes

  - New `/metrics` endpoint** compatible with Prometheus, exposing:
  - CPU usage (`system_cpu_percent`)
  - Memory usage (`system_memory_percent`)
  - Application uptime (`system_uptime_seconds`)

  - Added `prometheus_client` to `requirements.txt`.

  - Refactored `health.py`:
  - Removed legacy JSON metrics output.
  - Replaced with Prometheus-compatible metrics via `prometheus_client`.

  - Updated Prometheus configuration (`prometheus.yml`):
  - Replaced static LB DNS with placeholder (`<REPLACE_WITH_LOAD_BALANCER_DNS>`).
  - Ensured metrics are scraped from `/api/metrics`.

  - Modified `terraform/main.tf`:
  - Added ingress rule for HTTPS traffic (port 443) to ECS security group.

 Next steps

- Replace the placeholder in `prometheus.yml` with the actual Load Balancer DNS.
- Consider exposing additional application-specific metrics (e.g., request count, response time).
